### PR TITLE
feat: add local MQTT mode to bypass cloud API

### DIFF
--- a/custom_components/fossibot-ha/config_flow.py
+++ b/custom_components/fossibot-ha/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Fossibot integration."""
 
 import logging
+import re
 from typing import Any, Dict, Optional
 
 import voluptuous as vol
@@ -8,10 +9,27 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import DOMAIN, CONF_DEVELOPER_MODE
+from .const import (
+    DOMAIN,
+    CONF_DEVELOPER_MODE,
+    CONF_CONNECTION_MODE,
+    CONNECTION_MODE_CLOUD,
+    CONNECTION_MODE_LOCAL,
+    CONF_MQTT_HOST,
+    CONF_MQTT_PORT,
+    CONF_DEVICE_MAC,
+)
 from .sydpower.connector import SydpowerConnector
+from .sydpower.const import MQTT_PORT
 
 _LOGGER = logging.getLogger(__name__)
+
+MAC_PATTERN = re.compile(r"^[0-9A-Fa-f]{12}$")
+
+
+def _normalize_mac(raw: str) -> str:
+    """Strip colons/dashes and uppercase a MAC address."""
+    return raw.replace(":", "").replace("-", "").upper().strip()
 
 
 class FossibotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -26,7 +44,38 @@ class FossibotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:
-        """Handle the initial step."""
+        """Handle the initial step — choose connection mode."""
+        if user_input is not None:
+            mode = user_input.get(CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD)
+            self._data[CONF_CONNECTION_MODE] = mode
+
+            if mode == CONNECTION_MODE_LOCAL:
+                return await self.async_step_local_mqtt()
+
+            return await self.async_step_cloud()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_CONNECTION_MODE, default=CONNECTION_MODE_CLOUD
+                    ): vol.In(
+                        {
+                            CONNECTION_MODE_CLOUD: "Cloud API (username/password)",
+                            CONNECTION_MODE_LOCAL: "Local MQTT (no cloud needed)",
+                        }
+                    ),
+                }
+            ),
+        )
+
+    # ── Cloud flow ───────────────────────────────────────────────────
+
+    async def async_step_cloud(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        """Handle cloud credential input."""
         errors: Dict[str, str] = {}
 
         if user_input is not None:
@@ -38,7 +87,7 @@ class FossibotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_validate()
 
         return self.async_show_form(
-            step_id="user",
+            step_id="cloud",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_USERNAME): str,
@@ -69,7 +118,7 @@ class FossibotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_validate(
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:
-        """Validate the credentials."""
+        """Validate the cloud credentials."""
         try:
             connector = SydpowerConnector(
                 self._data[CONF_USERNAME],
@@ -92,7 +141,7 @@ class FossibotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception as error:
             _LOGGER.error("Failed to connect: %s", error)
             return self.async_show_form(
-                step_id="user",
+                step_id="cloud",
                 data_schema=vol.Schema(
                     {
                         vol.Required(
@@ -108,6 +157,104 @@ class FossibotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 errors={"base": "cannot_connect"},
             )
+
+    # ── Local MQTT flow ──────────────────────────────────────────────
+
+    async def async_step_local_mqtt(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        """Handle local MQTT configuration."""
+        errors: Dict[str, str] = {}
+
+        if user_input is not None:
+            mqtt_host = user_input.get(CONF_MQTT_HOST, "").strip()
+            mqtt_port = user_input.get(CONF_MQTT_PORT, MQTT_PORT)
+            raw_mac = user_input.get(CONF_DEVICE_MAC, "")
+            device_mac = _normalize_mac(raw_mac)
+
+            if not mqtt_host:
+                errors[CONF_MQTT_HOST] = "invalid_host"
+            elif not MAC_PATTERN.match(device_mac):
+                errors[CONF_DEVICE_MAC] = "invalid_mac"
+            else:
+                self._data.update(
+                    {
+                        CONF_MQTT_HOST: mqtt_host,
+                        CONF_MQTT_PORT: mqtt_port,
+                        CONF_DEVICE_MAC: device_mac,
+                    }
+                )
+                return await self.async_step_validate_local()
+
+        return self.async_show_form(
+            step_id="local_mqtt",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MQTT_HOST,
+                        default=self._data.get(CONF_MQTT_HOST, ""),
+                    ): str,
+                    vol.Required(
+                        CONF_MQTT_PORT,
+                        default=self._data.get(CONF_MQTT_PORT, MQTT_PORT),
+                    ): int,
+                    vol.Required(
+                        CONF_DEVICE_MAC,
+                        default=self._data.get(CONF_DEVICE_MAC, ""),
+                    ): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_validate_local(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        """Validate the local MQTT connection."""
+        try:
+            connector = SydpowerConnector(
+                username=None,
+                password=None,
+                connection_mode=CONNECTION_MODE_LOCAL,
+                mqtt_host=self._data[CONF_MQTT_HOST],
+                mqtt_port=self._data[CONF_MQTT_PORT],
+                device_mac=self._data[CONF_DEVICE_MAC],
+            )
+
+            success = await connector.connect()
+            if not success:
+                raise Exception("Failed to connect to local MQTT broker")
+
+            await connector.disconnect()
+
+            return self.async_create_entry(
+                title=f"Local MQTT ({self._data[CONF_DEVICE_MAC]})",
+                data=self._data,
+            )
+        except Exception as error:
+            _LOGGER.error("Failed to connect to local MQTT: %s", error)
+            return self.async_show_form(
+                step_id="local_mqtt",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_MQTT_HOST,
+                            default=self._data.get(CONF_MQTT_HOST, ""),
+                        ): str,
+                        vol.Required(
+                            CONF_MQTT_PORT,
+                            default=self._data.get(CONF_MQTT_PORT, MQTT_PORT),
+                        ): int,
+                        vol.Required(
+                            CONF_DEVICE_MAC,
+                            default=self._data.get(CONF_DEVICE_MAC, ""),
+                        ): str,
+                    }
+                ),
+                errors={"base": "cannot_connect"},
+            )
+
+    # ── Reauth (cloud only) ─────────────────────────────────────────
 
     async def async_step_reauth(
         self, entry_data: Dict[str, Any]

--- a/custom_components/fossibot-ha/const.py
+++ b/custom_components/fossibot-ha/const.py
@@ -9,3 +9,11 @@ CONF_SCAN_INTERVAL = "scan_interval"
 DEFAULT_SCAN_INTERVAL = 30
 
 CONF_DEVELOPER_MODE = "developer_mode"
+
+# Local MQTT mode
+CONF_CONNECTION_MODE = "connection_mode"
+CONNECTION_MODE_CLOUD = "cloud"
+CONNECTION_MODE_LOCAL = "local_mqtt"
+CONF_MQTT_HOST = "mqtt_host"
+CONF_MQTT_PORT = "mqtt_port"
+CONF_DEVICE_MAC = "device_mac"

--- a/custom_components/fossibot-ha/coordinator.py
+++ b/custom_components/fossibot-ha/coordinator.py
@@ -12,7 +12,14 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    CONF_CONNECTION_MODE,
+    CONNECTION_MODE_LOCAL,
+    CONF_MQTT_HOST,
+    CONF_MQTT_PORT,
+    CONF_DEVICE_MAC,
+)
 from .sydpower.connector import SydpowerConnector
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,11 +42,21 @@ class FossibotDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=update_interval,
         )
 
-        self.connector = SydpowerConnector(
-            config.get("username"),
-            config.get("password"),
-            developer_mode=config.get("developer_mode", False),
-        )
+        connection_mode = config.get(CONF_CONNECTION_MODE, "cloud")
+
+        if connection_mode == CONNECTION_MODE_LOCAL:
+            self.connector = SydpowerConnector(
+                connection_mode=CONNECTION_MODE_LOCAL,
+                mqtt_host=config.get(CONF_MQTT_HOST),
+                mqtt_port=config.get(CONF_MQTT_PORT, 8083),
+                device_mac=config.get(CONF_DEVICE_MAC),
+            )
+        else:
+            self.connector = SydpowerConnector(
+                username=config.get("username"),
+                password=config.get("password"),
+                developer_mode=config.get("developer_mode", False),
+            )
         self._shutdown_event = asyncio.Event()
         self._failed_updates_count = 0
         self._last_successful_update = time.time()

--- a/custom_components/fossibot-ha/sydpower/connector.py
+++ b/custom_components/fossibot-ha/sydpower/connector.py
@@ -40,11 +40,26 @@ COMMANDS = {
 class SydpowerConnector:
     """Main class for Fossibot/Sydpower API connection."""
 
-    def __init__(self, username: str, password: str, developer_mode: bool = False):
+    def __init__(
+        self,
+        username: str = None,
+        password: str = None,
+        developer_mode: bool = False,
+        connection_mode: str = "cloud",
+        mqtt_host: str = None,
+        mqtt_port: int = MQTT_PORT,
+        device_mac: str = None,
+    ):
         self.username = username
         self.password = password
         self.developer_mode = developer_mode
         self._logger = SmartLogger(__name__)
+
+        # Connection mode
+        self._connection_mode = connection_mode
+        self._local_mqtt_host = mqtt_host
+        self._local_mqtt_port = mqtt_port
+        self._local_device_mac = device_mac
 
         self.api_client: Optional[APIClient] = None
         self.mqtt_client: Optional[MQTTClient] = None
@@ -64,8 +79,139 @@ class SydpowerConnector:
         # Last successful connection timestamp
         self._last_successful_communication = 0
 
+    @property
+    def is_local_mqtt(self) -> bool:
+        """Return True if using local MQTT mode."""
+        return self._connection_mode == "local_mqtt"
+
     async def connect(self) -> bool:
         """Connect to the API and MQTT broker. Returns True if successful."""
+        if self.is_local_mqtt:
+            return await self._connect_local_mqtt()
+        return await self._connect_cloud()
+
+    async def _connect_local_mqtt(self) -> bool:
+        """Connect directly to a local MQTT broker, bypassing the cloud API."""
+        if self._reconnection_in_progress:
+            self._logger.debug(
+                "Connection attempt while reconnection in progress, waiting..."
+            )
+            try:
+                await asyncio.wait_for(
+                    self._reconnection_event.wait(), timeout=15.0
+                )
+            except asyncio.TimeoutError:
+                self._logger.error("Timeout waiting for reconnection")
+                return False
+
+            if self.mqtt_client and self.mqtt_client.connected.is_set():
+                return True
+
+        if self.mqtt_client and self.mqtt_client.connected.is_set():
+            return True
+
+        try:
+            lock_acquired = await asyncio.wait_for(
+                self._connection_lock.acquire(), timeout=10.0
+            )
+        except asyncio.TimeoutError:
+            self._logger.error("Timeout acquiring connection lock")
+            return False
+
+        if not lock_acquired:
+            return False
+
+        try:
+            if self.loop is None:
+                self.loop = asyncio.get_running_loop()
+
+            if self.mqtt_client is None:
+                self.mqtt_client = MQTTClient(self.loop)
+                self.mqtt_client.on_disconnect_callback = (
+                    self._handle_mqtt_disconnect
+                )
+
+            device_mac = self._local_device_mac
+            mqtt_host = self._local_mqtt_host
+            mqtt_port = self._local_mqtt_port
+
+            # Build device dict with defaults
+            self.devices = {
+                device_mac: {
+                    "_modbus_address": REGISTER_MODBUS_ADDRESS,
+                    "_modbus_count": 80,
+                }
+            }
+
+            device_ids = [device_mac]
+
+            self._logger.info(
+                "Local MQTT: connecting to %s:%d for device %s",
+                mqtt_host, mqtt_port, device_mac,
+            )
+
+            # Use "anonymous" as token — local EMQX accepts any credentials
+            mqtt_token = "anonymous"
+
+            await self.mqtt_client.connect(
+                mqtt_token, device_ids, mqtt_host, mqtt_port
+            )
+
+            try:
+                await asyncio.wait_for(
+                    self.mqtt_client.connected.wait(), timeout=15.0
+                )
+            except asyncio.TimeoutError:
+                self._logger.error(
+                    "Timeout waiting for MQTT connection to %s", mqtt_host
+                )
+                await self._cleanup()
+                return False
+
+            # Try to verify the device responds
+            try:
+                verified = await asyncio.wait_for(
+                    self._verify_connection(), timeout=10.0
+                )
+                if verified:
+                    self._last_successful_communication = time.time()
+                    self._logger.info(
+                        "Local MQTT: connected and verified on %s:%d",
+                        mqtt_host, mqtt_port,
+                    )
+                    return True
+            except asyncio.TimeoutError:
+                self._logger.warning(
+                    "Local MQTT: verification timeout for %s", mqtt_host
+                )
+
+            # Accept broker connection even if device didn't respond
+            # (device may be off/sleeping)
+            if self.mqtt_client and self.mqtt_client.connected.is_set():
+                self._logger.warning(
+                    "Local MQTT: device not responding — accepting broker "
+                    "connection. Will recover when device is reachable."
+                )
+                self._last_successful_communication = time.time()
+                return True
+
+            self._logger.error("Local MQTT: connection failed")
+            await self._cleanup()
+            return False
+
+        except asyncio.CancelledError:
+            self._logger.warning("Connect operation was cancelled")
+            raise
+        except Exception as e:
+            self._logger.error("Error during local MQTT connection: %s", e)
+            await self._cleanup()
+            return False
+        finally:
+            if self._connection_lock.locked():
+                self._connection_lock.release()
+
+    async def _connect_cloud(self) -> bool:
+        """Connect via cloud API (original flow)."""
         fallback_hosts = MQTT_HOSTS_DEV if self.developer_mode else MQTT_HOSTS_PROD
 
         if self._reconnection_in_progress:

--- a/custom_components/fossibot-ha/translations/en.json
+++ b/custom_components/fossibot-ha/translations/en.json
@@ -4,6 +4,12 @@
             "user": {
                 "title": "Connect to Fossibot",
                 "data": {
+                    "connection_mode": "Connection mode"
+                }
+            },
+            "cloud": {
+                "title": "Cloud API Credentials",
+                "data": {
                     "username": "Username",
                     "password": "Password",
                     "show_advanced": "Show advanced options"
@@ -13,6 +19,15 @@
                 "title": "Advanced Options",
                 "data": {
                     "developer_mode": "Enable developer mode (connects to test environment)"
+                }
+            },
+            "local_mqtt": {
+                "title": "Local MQTT Configuration",
+                "description": "Connect directly to a local EMQX broker. Find the device MAC address in the EMQX dashboard under Monitoring > Clients.",
+                "data": {
+                    "mqtt_host": "MQTT broker IP address",
+                    "mqtt_port": "MQTT broker port",
+                    "device_mac": "Device MAC address (e.g. AABBCCDDEEFF)"
                 }
             },
             "reauth_confirm": {
@@ -25,7 +40,9 @@
             }
         },
         "error": {
-            "cannot_connect": "Failed to connect, please check credentials"
+            "cannot_connect": "Failed to connect, please check your settings",
+            "invalid_host": "Invalid MQTT broker address",
+            "invalid_mac": "Invalid MAC address. Use 12 hex characters (e.g. AABBCCDDEEFF)"
         },
         "abort": {
             "reauth_successful": "Reauthentication successful"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,3 +77,49 @@ if "fossibot_ha" not in sys.modules:
     sys.modules["fossibot_ha.sydpower.modbus"] = modbus_mod
     modbus_spec.loader.exec_module(modbus_mod)
     sydpower_pkg.modbus = modbus_mod
+
+    # Load logger (used by connector/mqtt_client)
+    logger_spec = importlib.util.spec_from_file_location(
+        "fossibot_ha.sydpower.logger",
+        sydpower_dir / "logger.py",
+    )
+    logger_mod = importlib.util.module_from_spec(logger_spec)
+    sys.modules["fossibot_ha.sydpower.logger"] = logger_mod
+    logger_spec.loader.exec_module(logger_mod)
+    sydpower_pkg.logger = logger_mod
+
+    # Stub api_client (has aiohttp dependency we don't need)
+    api_mock = MagicMock()
+    sys.modules["fossibot_ha.sydpower.api_client"] = api_mock
+    sydpower_pkg.api_client = api_mock
+
+    # Load mqtt_client
+    mqtt_spec = importlib.util.spec_from_file_location(
+        "fossibot_ha.sydpower.mqtt_client",
+        sydpower_dir / "mqtt_client.py",
+    )
+    mqtt_mod = importlib.util.module_from_spec(mqtt_spec)
+    sys.modules["fossibot_ha.sydpower.mqtt_client"] = mqtt_mod
+    mqtt_spec.loader.exec_module(mqtt_mod)
+    sydpower_pkg.mqtt_client = mqtt_mod
+
+    # Load connector
+    connector_spec = importlib.util.spec_from_file_location(
+        "fossibot_ha.sydpower.connector",
+        sydpower_dir / "connector.py",
+    )
+    connector_mod = importlib.util.module_from_spec(connector_spec)
+    sys.modules["fossibot_ha.sydpower.connector"] = connector_mod
+    connector_spec.loader.exec_module(connector_mod)
+    sydpower_pkg.connector = connector_mod
+
+    # Load HA-level const (has no HA deps, only string constants)
+    ha_const_spec = importlib.util.spec_from_file_location(
+        "fossibot_ha.const",
+        INTEGRATION_DIR / "const.py",
+    )
+    ha_const_mod = importlib.util.module_from_spec(ha_const_spec)
+    sys.modules["fossibot_ha.const"] = ha_const_mod
+    ha_const_spec.loader.exec_module(ha_const_mod)
+    pkg.const = ha_const_mod
+

--- a/tests/test_local_mqtt.py
+++ b/tests/test_local_mqtt.py
@@ -1,0 +1,245 @@
+"""Tests for local MQTT mode: connector, config flow, and coordinator initialization.
+
+These tests verify the new local MQTT mode works correctly without
+requiring a running MQTT broker or Home Assistant instance.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Import the connector (modbus/const have no HA deps)
+from fossibot_ha.sydpower.connector import SydpowerConnector
+from fossibot_ha.sydpower.const import REGISTER_MODBUS_ADDRESS, MQTT_PORT
+
+
+def _run(coro):
+    """Run a coroutine synchronously (no pytest-asyncio needed)."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# SydpowerConnector — local MQTT mode
+# ---------------------------------------------------------------------------
+
+class TestConnectorLocalMqttInit:
+    """Test SydpowerConnector initialization in local MQTT mode."""
+
+    def test_local_mqtt_mode_flag(self):
+        c = SydpowerConnector(
+            connection_mode="local_mqtt",
+            mqtt_host="10.20.30.21",
+            mqtt_port=8083,
+            device_mac="AABBCCDDEEFF",
+        )
+        assert c.is_local_mqtt is True
+
+    def test_cloud_mode_flag_default(self):
+        c = SydpowerConnector(username="u", password="p")
+        assert c.is_local_mqtt is False
+
+    def test_cloud_mode_flag_explicit(self):
+        c = SydpowerConnector(
+            username="u", password="p", connection_mode="cloud"
+        )
+        assert c.is_local_mqtt is False
+
+    def test_local_params_stored(self):
+        c = SydpowerConnector(
+            connection_mode="local_mqtt",
+            mqtt_host="192.168.1.10",
+            mqtt_port=9999,
+            device_mac="112233445566",
+        )
+        assert c._local_mqtt_host == "192.168.1.10"
+        assert c._local_mqtt_port == 9999
+        assert c._local_device_mac == "112233445566"
+
+    def test_no_api_client_needed(self):
+        c = SydpowerConnector(
+            connection_mode="local_mqtt",
+            mqtt_host="10.20.30.21",
+            device_mac="AABBCCDDEEFF",
+        )
+        assert c.api_client is None
+        assert c.username is None
+        assert c.password is None
+
+
+def _make_mock_mqtt(connected=True, data_available=True, devices=None):
+    """Create a mock MQTT client for testing."""
+    mock = MagicMock()
+    mock.connected = asyncio.Event()
+    mock.data_updated = asyncio.Event()
+    mock.devices = devices or {}
+    mock.disconnect = AsyncMock()
+    mock.clear_message_cache = MagicMock()
+    mock.publish_command = MagicMock()
+    mock.on_disconnect_callback = None
+
+    async def fake_connect(*args, **kwargs):
+        if connected:
+            mock.connected.set()
+        if data_available:
+            mock.data_updated.set()
+
+    mock.connect = AsyncMock(side_effect=fake_connect)
+    return mock
+
+
+class TestConnectorLocalMqttConnect:
+    """Test the local MQTT connect flow with mocked MQTT client."""
+
+    def _make_connector(self):
+        return SydpowerConnector(
+            connection_mode="local_mqtt",
+            mqtt_host="10.20.30.21",
+            mqtt_port=8083,
+            device_mac="AABBCCDDEEFF",
+        )
+
+    def test_connect_builds_device_dict(self):
+        """connect() should build devices dict with default modbus params."""
+        connector = self._make_connector()
+        mock_mqtt = _make_mock_mqtt(
+            devices={"AABBCCDDEEFF": {"soc": 75.0}}
+        )
+
+        with patch(
+            "fossibot_ha.sydpower.connector.MQTTClient",
+            return_value=mock_mqtt,
+        ):
+            result = _run(connector.connect())
+
+        assert result is True
+        assert "AABBCCDDEEFF" in connector.devices
+        assert connector.devices["AABBCCDDEEFF"]["_modbus_address"] == REGISTER_MODBUS_ADDRESS
+        assert connector.devices["AABBCCDDEEFF"]["_modbus_count"] == 80
+
+    def test_connect_uses_anonymous_token(self):
+        """connect() should pass 'anonymous' as mqtt_token."""
+        connector = self._make_connector()
+        mock_mqtt = _make_mock_mqtt(
+            devices={"AABBCCDDEEFF": {"soc": 50.0}}
+        )
+
+        with patch(
+            "fossibot_ha.sydpower.connector.MQTTClient",
+            return_value=mock_mqtt,
+        ):
+            _run(connector.connect())
+
+        mock_mqtt.connect.assert_called_once_with(
+            "anonymous",
+            ["AABBCCDDEEFF"],
+            "10.20.30.21",
+            8083,
+        )
+
+    def test_connect_no_api_calls(self):
+        """Local MQTT mode should never create or call APIClient."""
+        connector = self._make_connector()
+        mock_mqtt = _make_mock_mqtt(
+            devices={"AABBCCDDEEFF": {"soc": 50.0}}
+        )
+
+        with patch(
+            "fossibot_ha.sydpower.connector.MQTTClient",
+            return_value=mock_mqtt,
+        ), patch(
+            "fossibot_ha.sydpower.connector.APIClient"
+        ) as api_mock:
+            _run(connector.connect())
+
+        api_mock.assert_not_called()
+        assert connector.api_client is None
+
+    def test_connect_accepts_broker_when_device_offline(self):
+        """If device doesn't respond but broker connects, accept it."""
+        connector = self._make_connector()
+        mock_mqtt = _make_mock_mqtt(
+            connected=True, data_available=False, devices={}
+        )
+
+        with patch(
+            "fossibot_ha.sydpower.connector.MQTTClient",
+            return_value=mock_mqtt,
+        ):
+            result = _run(connector.connect())
+
+        # Should still accept the broker connection
+        assert result is True
+
+    def test_connect_fails_when_broker_unreachable(self):
+        """If broker doesn't connect, return False."""
+        connector = self._make_connector()
+        mock_mqtt = _make_mock_mqtt(
+            connected=False, data_available=False, devices={}
+        )
+
+        with patch(
+            "fossibot_ha.sydpower.connector.MQTTClient",
+            return_value=mock_mqtt,
+        ):
+            result = _run(connector.connect())
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Config flow — MAC normalization
+# ---------------------------------------------------------------------------
+
+def _normalize_mac(raw: str) -> str:
+    """Mirror of config_flow._normalize_mac for testing."""
+    return raw.replace(":", "").replace("-", "").upper().strip()
+
+
+class TestMacNormalization:
+    """Test MAC address normalization logic (mirrors config_flow._normalize_mac)."""
+
+    def test_already_clean(self):
+        assert _normalize_mac("AABBCCDDEEFF") == "AABBCCDDEEFF"
+
+    def test_with_colons(self):
+        assert _normalize_mac("AA:BB:CC:DD:EE:FF") == "AABBCCDDEEFF"
+
+    def test_with_dashes(self):
+        assert _normalize_mac("aa-bb-cc-dd-ee-ff") == "AABBCCDDEEFF"
+
+    def test_lowercase(self):
+        assert _normalize_mac("aabbccddeeff") == "AABBCCDDEEFF"
+
+    def test_with_spaces(self):
+        assert _normalize_mac("  AABBCCDDEEFF  ") == "AABBCCDDEEFF"
+
+    def test_mixed_separators(self):
+        assert _normalize_mac("AA:BB-CC:DD-EE:FF") == "AABBCCDDEEFF"
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+class TestLocalMqttConstants:
+    """Test that new constants exist and have correct values."""
+
+    def test_connection_mode_constants(self):
+        from fossibot_ha.const import (
+            CONF_CONNECTION_MODE,
+            CONNECTION_MODE_CLOUD,
+            CONNECTION_MODE_LOCAL,
+            CONF_MQTT_HOST,
+            CONF_MQTT_PORT,
+            CONF_DEVICE_MAC,
+        )
+        assert CONF_CONNECTION_MODE == "connection_mode"
+        assert CONNECTION_MODE_CLOUD == "cloud"
+        assert CONNECTION_MODE_LOCAL == "local_mqtt"
+        assert CONF_MQTT_HOST == "mqtt_host"
+        assert CONF_MQTT_PORT == "mqtt_port"
+        assert CONF_DEVICE_MAC == "device_mac"


### PR DESCRIPTION
  **Summary**                                                                                                                               
                                                                                                                                        
  Adds a new Local MQTT connection mode that allows the integration to communicate with Fossibot batteries entirely over a local EMQX broker, without requiring cloud API authentication (api.sydpower.com).                                                                
                                                                                                                                        
  This is useful when:                                                                                                                  
  - The cloud API is unreachable or the account is blocked                                                                              
  - Users prefer a fully local setup with no cloud dependency for data polling
  - The battery is already connected to a local EMQX broker via DNS rewrite (as described in docs/LOCAL_MQTT.md)

  **What changed**

  - config_flow.py — First step now offers a choice between Cloud API and Local MQTT. The Local MQTT flow collects broker IP, port, and device MAC address. MAC input accepts colons, dashes, and mixed case (normalized automatically).
  - const.py — New config constants: CONF_CONNECTION_MODE, CONF_MQTT_HOST, CONF_MQTT_PORT, CONF_DEVICE_MAC.
  - connector.py — New _connect_local_mqtt() method that skips API authentication, MQTT token fetch, and device discovery. Connects directly with anonymous credentials and default Modbus parameters (address=17, count=80). Accepts broker connection even if the device is offline (auto-recovers on next poll).
  - coordinator.py — Routes to the correct SydpowerConnector initialization based on connection_mode.
  - translations/en.json — UI strings for the new Local MQTT config step and validation errors.
  - tests/conftest.py — Extended test harness to load connector, mqtt_client, and logger modules.
  - tests/test_local_mqtt.py — 17 new tests covering connector init, connect flow (mocked), MAC normalization, and constants.

  **How it works**

  1. User selects Local MQTT during integration setup
  2. Provides the EMQX broker address and the device MAC (visible in EMQX dashboard under Monitoring > Clients)
  3. The integration connects to the local broker with anonymous as the MQTT username (local EMQX uses anonymous auth as per the LOCAL_MQTT guide)
  4. Polls the battery via Modbus func 03 over MQTT — same as the cloud path, just without the API dependency
  5. All sensors, switches, selects, and numbers work identically to cloud mode

  **Backwards compatibility**

  - No breaking changes — existing Cloud API installations are unaffected
  - The connection_mode config key defaults to "cloud" when absent, so existing config entries continue to work without migration
  - Cloud mode code paths are untouched (refactored into _connect_cloud() but logic is identical)

  **Test plan**

  - All 83 existing tests pass (modbus, entity definitions)
  - 17 new tests pass (local MQTT connector, MAC normalization, constants)
  - Verified live on a local EMQX broker — battery responds with full sensor + settings data over local MQTT without any API calls

