### PR TITLE
Use async_create_background_task for health-check loop

### DIFF
--- a/custom_components/fossibot-ha/coordinator.py
+++ b/custom_components/fossibot-ha/coordinator.py
@@ -60,8 +60,9 @@ class FossibotDataUpdateCoordinator(DataUpdateCoordinator):
         Must be called after the coordinator is registered with hass
         (i.e. after async_config_entry_first_refresh).
         """
-        self._health_check_task = self.hass.async_create_task(
-            self._health_check_loop()
+        self._health_check_task = self.hass.async_create_background_task(
+            self._health_check_loop(),
+            name="fossibot_health_check",
         )
         self._health_check_task.add_done_callback(
             self._handle_health_check_done


### PR DESCRIPTION
## Summary

`FossibotDataUpdateCoordinator.start_health_check` creates the health-check loop with `hass.async_create_task(...)`. Home Assistant tracks tasks created with `async_create_task` as "startup tasks" — bootstrap waits for them to finish before declaring the system ready. Because `_health_check_loop` is an infinite `while True` loop, it never finishes, so HA waits the full 5-minute bootstrap timeout and then logs a warning and continues.

This makes every Home Assistant boot (cold start, restart, reload) take ~5 minutes for users with the Fossibot integration installed.

This PR switches the call to `hass.async_create_background_task(coro, name=...)` which is the documented API for long-running tasks that should not be tracked by bootstrap. See https://developers.home-assistant.io/docs/api/core/#hass-async-create-background-task

## Evidence

Before the fix, on Home Assistant 2026.4.4 with Fossibot 2.0.1 installed:

```
WARNING [homeassistant.bootstrap] Setup timed out for bootstrap waiting on
  {<Task pending name='Task-1749'
    coro=<FossibotDataUpdateCoordinator._health_check_loop() running at
    .../fossibot/coordinator.py:...>
    cb=[set.remove(), FossibotDataUpdateCoordinator._handle_health_check_done()]>}
  - moving forward
INFO [homeassistant.bootstrap] Home Assistant initialized in 313.53s
```

After the fix, the same install boots in **14.14s** (≈22× faster). No other functional change observed; data updates and reconnection still work.

## Note about a similar pattern

`_trigger_reconnection` (around line 155 in `coordinator.py`) does:

```python
self.hass.async_create_task(self._handle_reconnection())
```

The docstring says "Trigger reconnection without blocking updates" / "Handle reconnection in background", so it likely intends background semantics too. I left it out of this PR to keep the change minimal and focused on the proven boot blocker, but happy to apply the same fix in a follow-up commit if maintainers prefer.

## Test plan

- [x] Apply patch on a Home Assistant 2026.4.4 install with Fossibot 2.0.1
- [x] Restart HA, observe `Home Assistant initialized in <30s` instead of `~313s`
- [x] Verify Fossibot data updates still arrive normally
- [x] Verify reconnection still triggers on simulated connection loss
