### PR TITLE
Use async_create_background_task for reconnection

### DIFF
--- a/custom_components/fossibot-ha/coordinator.py
+++ b/custom_components/fossibot-ha/coordinator.py
@@ -152,7 +152,10 @@ class FossibotDataUpdateCoordinator(DataUpdateCoordinator):
             "Multiple consecutive failures, initiating reconnection"
         )
         self._reconnection_in_progress = True
-        self.hass.async_create_task(self._handle_reconnection())
+        self.hass.async_create_background_task(
+            self._handle_reconnection(),
+            name="fossibot_reconnection",
+        )
 
     async def _handle_reconnection(self):
         """Handle reconnection in background."""


### PR DESCRIPTION
## Summary

Applies the same fix from PR #25 to the `_trigger_reconnection` method. The reconnection handler is a background operation that should not block Home Assistant startup.

## Changes

- Changed `async_create_task()` to `async_create_background_task()` in `_trigger_reconnection()`
- Added `name="fossibot_reconnection"` parameter for debugging

## Rationale

This mirrors the health-check loop fix: prevents HA bootstrap from waiting on long-running background tasks that intentionally run in the background and are not part of the startup critical path.

## Test Plan

- [x] Verify reconnection still triggers on consecutive update failures
- [x] Verify no bootstrap blocking occurs